### PR TITLE
Añadir archivos de AWS CLI a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ docker-compose.override.yml
 # Temporary files
 *.tmp
 .cache/
+
+# AWS CLI installation files
+aws/
+awscliv2.zip


### PR DESCRIPTION
- Ignorar aws/ y awscliv2.zip (archivos de instalación)
- Mantener repositorio limpio