### PR TITLE
fix: migrar crendenciales aws a Docker agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             agent {
                 docker {
                     image 'amazon/aws-cli:latest'
-                    args '-u root:root --entrypoint=""'
+                    args '-u root:root --entrypoint="" -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION'
                     reuseNode true
                 }
             }


### PR DESCRIPTION
- Añadir flags -e para AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
- Resolver eror 'Unable to locate credentials
- Permitir que container aws-cli acceda a credenciales

Fixes #15